### PR TITLE
Fix isConstraintsBatch loop not applying

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,9 @@ exports.createTable = async (schema, knex, opts) => {
         knex = schema.knex;
     }
 
-    if (!await knex.schema.hasTable(schema.protoProps.tableName)) {
+    if (!await knex.schema.hasTable(schema.protoProps.tableName) || opts.isConstraintsBatch) {
+
+        let hasCreatedTable = false;
 
         if (!opts.isConstraintsBatch) {
 
@@ -122,6 +124,8 @@ exports.createTable = async (schema, knex, opts) => {
                         schema.columns(table);
                     }
                 });
+
+                hasCreatedTable = true;
             }
 
             if (schema.isComposite) {
@@ -131,7 +135,7 @@ exports.createTable = async (schema, knex, opts) => {
 
         if (opts.isColumnsBatch) {
 
-            return;
+            return hasCreatedTable;
         }
 
         if (schema.constraints || opts.constraints) {
@@ -214,13 +218,17 @@ exports.buildShelf = async (conns, schemas, opts) => {
             for (let s = 0; s < schemaGroup.length; ++s) {
                 const schema = schemaGroup[s];
 
-                await exports.createTable(schema, bookshelf.knex, Object.assign({ isColumnsBatch: true }, opts.schemas[schema.name]));
+                schema.hasCreatedTable = await exports.createTable(schema, bookshelf.knex, Object.assign({ isColumnsBatch: true }, opts.schemas[schema.name]));
             }
 
             for (let s = 0; s < schemaGroup.length; ++s) {
                 const schema = schemaGroup[s];
 
-                await exports.createTable(schema, bookshelf.knex, Object.assign({ isConstraintsBatch: true }, opts.schemas[schema.name]));
+                if (schema.hasCreatedTable) {
+                    await exports.createTable(schema, bookshelf.knex, Object.assign({isConstraintsBatch: true}, opts.schemas[schema.name]));
+                }
+
+                delete schema.hasCreatedTable;
 
                 shelf.models[schema.name] = exports.loadModel(schema, bookshelf);
             }


### PR DESCRIPTION
Track a flag (`hasCreatedTable`) for every schema that has been created successfully and only then it will be applied of its constraints to avoid errors of constraints already existing and for a clean table creation.