### PR TITLE
Schema exposure and hapi queries restructure

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -294,13 +294,23 @@ exports.generateHapiPlugin = (packageJson, schemas, opts) => {
                         options.schemas[modelKey] &&
                         options.schemas[modelKey].method);
 
+                    const schema = function () {
+
+                        return model.schema;
+                    };
+
+                    methods.push({
+                        name: `models.${modelKey}.schema`,
+                        method: schema
+                    });
+
                     for (const queryKey in model.do) {
                         /* $lab:coverage:off$ */
                         if (model.do.hasOwnProperty(queryKey)) {
                             /* $lab:coverage:on$ */
 
                             methods.push({
-                                name: `models.${modelKey}.${queryKey}`,
+                                name: `models.${modelKey}.do.${queryKey}`,
                                 method: model.do[queryKey],
                                 options: Object.assign({}, mopts[queryKey])
                             });

--- a/test/index.js
+++ b/test/index.js
@@ -481,13 +481,15 @@ describe('lib', () => {
         const models = server.methods.models;
         const modelsx = serverx.methods.models;
 
-        await models.soloTable.create({ label: 'farboo' });
+        expect(models.soloTable.schema()).to.exist();
 
-        let res = await models.soloTable.obtain({ id: 1 });
+        await models.soloTable.do.create({ label: 'farboo' });
+
+        let res = await models.soloTable.do.obtain({ id: 1 });
 
         expect(res.label).to.equal('farboo');
 
-        res = await modelsx.soloTable.browse();
+        res = await modelsx.soloTable.do.browse();
 
         expect(res[0].label).to.equal('farboo');
 
@@ -495,7 +497,7 @@ describe('lib', () => {
             plugin: Lib.generateHapiPlugin('../package.json', Schemas)
         })).to.reject(Error, 'Missing connections');
 
-        await expect(models.soloTable.obtain({
+        await expect(models.soloTable.do.obtain({
             id: 2
         }, {
             require: true
@@ -508,6 +510,19 @@ describe('lib', () => {
         await server.knexes.default.schema.dropTableIfExists(Schemas[2].protoProps.tableName);
         await server.knexes.default.schema.dropTableIfExists(Schemas[1].protoProps.tableName);
         await server.knexes.default.schema.dropTableIfExists(Schemas[0].protoProps.tableName);
+
+        server.route({
+            method: 'get',
+            path: '/',
+            handler: async (request) => {
+
+                return request.server.methods.models.soloTable.schema().name;
+            }
+        });
+
+        res = await server.inject('/');
+
+        expect(res.result).to.equal('soloTable');
     });
 
     it('exports.generateShelf', async () => {
@@ -552,13 +567,13 @@ describe('lib', () => {
 
         const models = server.methods.models;
 
-        await models.soloTable.create({ label: 'farboo' });
+        await models.soloTable.do.create({ label: 'farboo' });
 
-        res = await models.soloTable.obtain({ id: 1 });
+        res = await models.soloTable.do.obtain({ id: 1 });
 
         expect(res.label).to.equal('farboo');
 
-        res = await models.soloTable.browse();
+        res = await models.soloTable.do.browse();
 
         expect(res[0].label).to.equal('farboo');
 


### PR DESCRIPTION
Move queries to .do and expose model schema to hapi
Add unit test for schema exposure and query restructure for hapi